### PR TITLE
feat: profile image 삭제 시 팝업 추가 및 동의화면 팝업 간격 수정

### DIFF
--- a/presentation/src/main/java/com/devndev/lamp/presentation/ui/common/LampPopup.kt
+++ b/presentation/src/main/java/com/devndev/lamp/presentation/ui/common/LampPopup.kt
@@ -2,18 +2,23 @@ package com.devndev.lamp.presentation.ui.common
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import com.devndev.lamp.presentation.ui.theme.Gray
@@ -37,7 +42,7 @@ fun OneButtonPopup(onDismissRequest: () -> Unit) {
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 20.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp)
+                verticalArrangement = Arrangement.spacedBy(10.dp),
             ) {
                 // todo 추후 팝업 내용 수정 서버에서 어떻게 받느냐에 따라 달라짐
                 Column() {
@@ -57,13 +62,21 @@ fun OneButtonPopup(onDismissRequest: () -> Unit) {
                     )
                 }
             }
-            HorizontalDivider(thickness = 1.dp, color = Gray3)
-            Text(
-                text = "닫기",
-                color = Color.White,
-                style = Typography.medium18,
-                modifier = Modifier.clickable { onDismissRequest() }
-            )
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                HorizontalDivider(thickness = 1.dp, color = Gray3)
+                Text(
+                    text = "닫기",
+                    color = Color.White,
+                    style = Typography.medium18,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(
+                            indication = null,
+                            interactionSource = remember { MutableInteractionSource() }
+                        ) { onDismissRequest() }
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/devndev/lamp/presentation/ui/common/LampPopup.kt
+++ b/presentation/src/main/java/com/devndev/lamp/presentation/ui/common/LampPopup.kt
@@ -4,8 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -13,14 +14,17 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import com.devndev.lamp.presentation.R
 import com.devndev.lamp.presentation.ui.theme.Gray
 import com.devndev.lamp.presentation.ui.theme.Gray3
 import com.devndev.lamp.presentation.ui.theme.Typography
@@ -32,7 +36,7 @@ fun OneButtonPopup(onDismissRequest: () -> Unit) {
     ) {
         Column(
             modifier = Modifier
-                .width(300.dp)
+                .width(340.dp)
                 .background(Gray, shape = RoundedCornerShape(15.dp))
                 .padding(top = 20.dp, bottom = 10.dp),
             verticalArrangement = Arrangement.spacedBy(20.dp),
@@ -42,7 +46,7 @@ fun OneButtonPopup(onDismissRequest: () -> Unit) {
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 20.dp),
-                verticalArrangement = Arrangement.spacedBy(10.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
             ) {
                 // todo 추후 팝업 내용 수정 서버에서 어떻게 받느냐에 따라 달라짐
                 Column() {
@@ -65,7 +69,7 @@ fun OneButtonPopup(onDismissRequest: () -> Unit) {
             Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
                 HorizontalDivider(thickness = 1.dp, color = Gray3)
                 Text(
-                    text = "닫기",
+                    text = stringResource(id = R.string.close),
                     color = Color.White,
                     style = Typography.medium18,
                     textAlign = TextAlign.Center,
@@ -76,6 +80,67 @@ fun OneButtonPopup(onDismissRequest: () -> Unit) {
                             interactionSource = remember { MutableInteractionSource() }
                         ) { onDismissRequest() }
                 )
+            }
+        }
+    }
+}
+
+@Composable
+fun TwoButtonPopup(onStartButtonClick: () -> Unit, onEndButtonClick: () -> Unit) {
+    Dialog(
+        onDismissRequest = { }
+    ) {
+        Column(
+            modifier = Modifier
+                .width(340.dp)
+                .background(Gray, shape = RoundedCornerShape(15.dp)),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(110.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(id = R.string.delete_profile_image),
+                    color = Color.White,
+                    style = Typography.semiBold20
+                )
+            }
+            Column(modifier = Modifier.height(44.dp)) {
+                HorizontalDivider(thickness = 1.dp, color = Gray3)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.no),
+                        color = Color.White,
+                        style = Typography.medium18,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .weight(1f)
+                            .clickable(
+                                indication = null,
+                                interactionSource = remember { MutableInteractionSource() }
+                            ) { onStartButtonClick() }
+                    )
+                    VerticalDivider(thickness = 1.dp, color = Gray3)
+                    Text(
+                        text = stringResource(id = R.string.yes),
+                        color = Color.White,
+                        style = Typography.medium18,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .weight(1f)
+                            .clickable(
+                                indication = null,
+                                interactionSource = remember { MutableInteractionSource() }
+                            ) { onEndButtonClick() }
+                    )
+                }
             }
         }
     }

--- a/presentation/src/main/java/com/devndev/lamp/presentation/ui/registration/ProfileScreen.kt
+++ b/presentation/src/main/java/com/devndev/lamp/presentation/ui/registration/ProfileScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -31,7 +32,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -45,6 +45,7 @@ import com.canhub.cropper.CropImageOptions
 import com.devndev.lamp.presentation.R
 import com.devndev.lamp.presentation.ui.common.LampBigTextField
 import com.devndev.lamp.presentation.ui.common.SelectionScreen
+import com.devndev.lamp.presentation.ui.common.TwoButtonPopup
 import com.devndev.lamp.presentation.ui.theme.Gray
 import com.devndev.lamp.presentation.ui.theme.ManColor
 import com.devndev.lamp.presentation.ui.theme.Typography
@@ -59,7 +60,10 @@ fun ProfileScreen(
 ) {
     val context = LocalContext.current
     var imageUri by remember { mutableStateOf<Uri?>(null) }
-    var imageIndex by remember { mutableStateOf(-1) }
+    var imageIndex by remember { mutableIntStateOf(-1) }
+
+    var isShowDeletePopup by remember { mutableStateOf(false) }
+    var deleteIndex by remember { mutableIntStateOf(-1) }
 
     var profileQuery by remember { mutableStateOf(profileIntro) }
     val maxProfileChar = 100
@@ -94,6 +98,28 @@ fun ProfileScreen(
         }
     }
 
+    if (isShowDeletePopup) {
+        TwoButtonPopup(
+            onStartButtonClick = {
+                isShowDeletePopup = false
+            },
+            onEndButtonClick = {
+                val updatedBitmap = bitmaps.toMutableList().apply {
+                    this[deleteIndex] = null
+
+                    if (deleteIndex > 0) {
+                        for (i in deleteIndex + 1 until size) {
+                            this[i - 1] = this[i]
+                        }
+                        this[size - 1] = null
+                    }
+                }
+                onBitmapsChange(updatedBitmap)
+                isShowDeletePopup = false
+            }
+        )
+    }
+
     SelectionScreen(text = stringResource(id = R.string.input_profile)) {
         Spacer(modifier = Modifier.height(15.dp))
         Text(
@@ -126,20 +152,9 @@ fun ProfileScreen(
                                 )
                             },
                             onDelete = {
-                                val updatedBitmaps = bitmaps.toMutableList().apply {
-                                    this[index] = null
-                                }
-                                onBitmapsChange(updatedBitmaps)
+                                deleteIndex = index
+                                isShowDeletePopup = true
                             },
-//                            onEdit = {
-//                                imageIndex = index
-//                                imageCropLauncher.launch(
-//                                    CropImageContractOptions(
-//                                        imageUri,
-//                                        CropImageOptions()
-//                                    )
-//                                )
-//                            },
                             isFirstImage = (index == 0)
                         )
                     }
@@ -167,7 +182,6 @@ fun ProfileImage(
     bitmap: Bitmap?,
     onClick: () -> Unit,
     onDelete: () -> Unit,
-//    onEdit: () -> Unit,
     isFirstImage: Boolean = false
 ) {
     val gradientBrush = Brush.horizontalGradient(
@@ -214,7 +228,7 @@ fun ProfileImage(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .size(24.dp)
-                    .background(Color.Gray.copy(alpha = 0.5f), RectangleShape)
+                    .background(color = Color.Transparent)
                     .clickable(onClick = onDelete)
             ) {
                 Icon(
@@ -224,21 +238,6 @@ fun ProfileImage(
                     modifier = Modifier.size(20.dp)
                 )
             }
-
-//            Box(
-//                modifier = Modifier
-//                    .align(Alignment.BottomStart)
-//                    .size(24.dp)
-//                    .background(Color.Gray.copy(alpha = 0.5f), RectangleShape)
-//                    .clickable(onClick = onEdit)
-//            ) {
-//                Icon(
-//                    painter = painterResource(id = R.drawable.baseline_edit_24),
-//                    contentDescription = null,
-//                    tint = Color.White,
-//                    modifier = Modifier.size(20.dp)
-//                )
-//            }
         } else {
             if (isFirstImage) {
                 MainProfileImage()

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -137,4 +137,9 @@
     <string name="optional_consent">(선택) 혜택/이벤트 정보 수신 동의</string>
 
     <string name="see_consent">보기</string>
+
+    <string name="close">닫기</string>
+    <string name="no">아니오</string>
+    <string name="yes">예</string>
+    <string name="delete_profile_image">사진을 삭제하시겠습니까?</string>
 </resources>


### PR DESCRIPTION
-profile image 삭제 시 팝업 추가
-profile image 삭제 시 뒤에 사진들 앞으로 당겨지도록 로직 수정
-동의화면 팝업 아래 닫기 버튼 간격 수정