### PR TITLE
feat: 채팅 리스트 화면, 채팅 화면 동작 수정

### DIFF
--- a/presentation/src/main/java/com/devndev/lamp/presentation/ui/alarm/AlarmScreen.kt
+++ b/presentation/src/main/java/com/devndev/lamp/presentation/ui/alarm/AlarmScreen.kt
@@ -357,7 +357,7 @@ fun getTimeAgo(isoTime: String): String {
     val zonedDateTime = ZonedDateTime.parse(isoTime, formatter)
 
     // Getting the current time in Korean Standard Time (KST) explicitly (UTC+9)
-    val now = ZonedDateTime.now(ZoneOffset.ofHours(9)).minusHours(9)
+    val now = ZonedDateTime.now(ZoneOffset.ofHours(9))
 
     // Calculating the duration between the provided time and now
     val duration = Duration.between(zonedDateTime, now)

--- a/presentation/src/main/java/com/devndev/lamp/presentation/ui/chatting/ChatListScreen.kt
+++ b/presentation/src/main/java/com/devndev/lamp/presentation/ui/chatting/ChatListScreen.kt
@@ -122,8 +122,7 @@ fun ChatListScreen(
                         .fillMaxSize()
                         .padding(horizontal = 16.dp),
                     horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(15.dp),
-                    reverseLayout = true
+                    verticalArrangement = Arrangement.spacedBy(15.dp)
                 ) {
                     items(state.chatList) { chat ->
                         Chat(

--- a/presentation/src/main/java/com/devndev/lamp/presentation/ui/chatting/ChatScreen.kt
+++ b/presentation/src/main/java/com/devndev/lamp/presentation/ui/chatting/ChatScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -70,6 +71,7 @@ import com.devndev.lamp.presentation.theme.Typography
 import com.devndev.lamp.presentation.theme.WomanColor
 import com.devndev.lamp.presentation.ui.common.ProfilePopup
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import java.time.OffsetDateTime
 import java.time.ZonedDateTime
@@ -101,6 +103,28 @@ fun ChatScreen(
     }
 
     val lazyListState = rememberLazyListState()
+
+    val isAtBottom = remember {
+        derivedStateOf {
+            val layoutInfo = lazyListState.layoutInfo
+            val totalItemsCount = layoutInfo.totalItemsCount
+            val lastVisibleItemIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: -1
+
+            lastVisibleItemIndex >= totalItemsCount - 2
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        snapshotFlow { isAtBottom.value }
+            .distinctUntilChanged()
+            .collect { atBottom ->
+                viewModel.setAtBottom(atBottom)
+
+                if (atBottom) {
+                    viewModel.setShowNewMessageBadge(false)
+                }
+            }
+    }
 
     LaunchedEffect(state.needScrollDown) {
         if (state.needScrollDown) {
@@ -158,8 +182,6 @@ fun ChatScreen(
             .imePadding(),
         verticalArrangement = Arrangement.SpaceBetween
     ) {
-//        LampTopBar(navController = navController, isAlarmIconNeed = true, color = Gray)
-
         ChatTopBar(
             chat = state,
             onBackClick = {
@@ -316,6 +338,31 @@ fun ChatScreen(
                     text = stringResource(id = R.string.send),
                     color = textColor,
                     style = Typography.normal12
+                )
+            }
+        }
+    }
+
+    if (state.showNewMessageBadge) {
+        Box(
+            Modifier.fillMaxSize().padding(bottom = 70.dp),
+            contentAlignment = Alignment.BottomCenter
+        ) {
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(22.dp))
+                    .background(Gray)
+                    .padding(horizontal = 10.dp, vertical = 5.dp)
+                    .clickable {
+                        viewModel.setNeedScrollDown(true)
+                        viewModel.setShowNewMessageBadge(false)
+                    },
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.new_message),
+                    color = Color.White,
+                    style = Typography.normal15
                 )
             }
         }

--- a/presentation/src/main/java/com/devndev/lamp/presentation/ui/chatting/ChatUiState.kt
+++ b/presentation/src/main/java/com/devndev/lamp/presentation/ui/chatting/ChatUiState.kt
@@ -14,5 +14,7 @@ data class ChatUiState(
     val chatMessage: List<ChatMessageDomainModel> = emptyList(),
     val chatItems: List<ChatItem> = emptyList(),
     val isLoading: Boolean = true,
-    val lastFetchedMessageId: String? = null
+    val lastFetchedMessageId: String? = null,
+    val isAtBottom: Boolean = true,
+    val showNewMessageBadge: Boolean = false
 )

--- a/presentation/src/main/java/com/devndev/lamp/presentation/ui/chatting/ChatViewModel.kt
+++ b/presentation/src/main/java/com/devndev/lamp/presentation/ui/chatting/ChatViewModel.kt
@@ -46,7 +46,7 @@ class ChatViewModel @Inject constructor(
             getChatListUseCase()
                 .onSuccess { chatList ->
                     Log.d(TAG, "getChatList Success")
-                    val sortedList = chatList.sortedBy { chatRoom ->
+                    val sortedList = chatList.sortedByDescending { chatRoom ->
                         val dateString = chatRoom.lastMessageInfo?.createdAt ?: chatRoom.startDate
                         parseDate(dateString)
                     }

--- a/presentation/src/main/java/com/devndev/lamp/presentation/ui/chatting/ChatViewModel.kt
+++ b/presentation/src/main/java/com/devndev/lamp/presentation/ui/chatting/ChatViewModel.kt
@@ -179,8 +179,14 @@ class ChatViewModel @Inject constructor(
                             _uiState.update { it.copy(chatMessage = updatedMessages) }
 
                             updateChatItems()
-                            if (chatMessage.userId == uiState.value.myInfo?.userId) {
+                            val isMine = chatMessage.userId == uiState.value.myInfo?.userId
+                            val isAtBottom = uiState.value.isAtBottom
+
+                            if (isMine || isAtBottom) {
                                 setNeedScrollDown(true)
+                                setShowNewMessageBadge(false)
+                            } else {
+                                setShowNewMessageBadge(true)
                             }
                         }
                     }
@@ -220,6 +226,14 @@ class ChatViewModel @Inject constructor(
 
     fun setNeedScrollDown(needScrollDown: Boolean) {
         _uiState.update { it.copy(needScrollDown = needScrollDown) }
+    }
+
+    fun setAtBottom(isAtBottom: Boolean) {
+        _uiState.update { it.copy(isAtBottom = isAtBottom) }
+    }
+
+    fun setShowNewMessageBadge(showNewMessage: Boolean) {
+        _uiState.update { it.copy(showNewMessageBadge = showNewMessage) }
     }
 
     private fun parseDate(dateStr: String): Date {

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -230,4 +230,6 @@
     <string name="say_hi">"반가운 인사로 대화를 시작해보세요"</string>
     <string name="register_appointment">"약속을 등록 해보세요"</string>
     <string name="send">"전송"</string>
+
+    <string name="new_message">"새 메세지"</string>
 </resources>


### PR DESCRIPTION
- 채팅 리스트 화면 최근 대화부터 스크롤 되도록 설정
- 채팅 화면에서 채팅 들어올 경우 스크롤이 하단에 있을 때는 새로운 채팅 표시, 하단이 아닐 경우 새 메시지 버튼 등작
- 새 메시지 버튼 표시 중 스크롤 하단으로 이동 시 메시지 미표시
- 채팅 리스트 마지막 메세지 시간 정상 표시되도록 수정